### PR TITLE
chore: avoid precision issues

### DIFF
--- a/tests/GTC_test.py
+++ b/tests/GTC_test.py
@@ -73,7 +73,7 @@ class MintInfo:
         self.minter = gtc.minter
         self.total_supply = gtc.totalSupply()
         self.mint_cap = gtc.mintCap()
-        self.max_mint_amount =  self.mint_cap/100 * self.total_supply 
+        self.max_mint_amount = (self.mint_cap * self.total_supply) / 100
         self.before_mint = gtc.balanceOf(_account)
         
 


### PR DESCRIPTION
The tests that were using minting were failing for me on Python 3.9.5. I have corrected the `max_mint_amount` to reflect exactly the calculation in the contract. This has fixed all the issues.

Before this change, the following are failing for me:
![failing-tests](https://user-images.githubusercontent.com/13678461/120549854-047e0d00-c3ec-11eb-87aa-e33be96e59c4.PNG)

failing due to precision issue:
![failing-because](https://user-images.githubusercontent.com/13678461/120549873-0a73ee00-c3ec-11eb-858f-a07f8a007b3a.PNG)

and not failing after the change in this PR:
![not-failing-after](https://user-images.githubusercontent.com/13678461/120549891-12339280-c3ec-11eb-9dc1-eb9518682cca.PNG)
